### PR TITLE
Add types for node-graceful-shutdown

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export function onShutdown(
+    name: (() => Promise<void>) | string | string[],
+    dependencies?: (() => Promise<void>) | string[],
+    handler?: () => Promise<void>
+): void;
+
+export function onShutdownError(callback: () => Promise<void>): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,4 @@ export function onShutdown(
     handler?: () => Promise<void>
 ): void;
 
-export function onShutdownError(callback: () => Promise<void>): void;
+export function onShutdownError(callback: (error: Error) => Promise<void>): void;


### PR DESCRIPTION
I liked what i saw and wanted to use it in my typescript project. Except there were no types available for this repository. So hereby a pull request containing the types for this repository. 

Example usage in typescript:
```
import { onShutdown, onShutdownError } from 'node-graceful-shutdown';

onShutdown(
    async (): Promise<void> => {
        console.log('Shutdown1');
    },
);

onShutdown(
    'name',
    async (): Promise<void> => {
        console.log('Shutdown2');
    },
);

onShutdown(
    'name2',
    ['name'],
    async (): Promise<void> => {
        console.log('Shutdown3');
        throw new Error('Shutdown error');
    },
);

onShutdownError(
    async (error: Error): Promise<void> => {
        console.log('Do something with the error...');
        console.log(error.message);
    },
);
```