### PR TITLE
tech/refactor getAllDependents func to be more performant

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,7 @@ function getDependencyTreeLeaves () {
 
 function getAllDependents (name) {
     return new Set(Array.from(dependencyTree.entries())
-        .filter(([_, dependencies]) => dependencies.indexOf(name) !== -1)
-        .filter(([parent]) => handlers.has(parent))
+        .filter(([parent, dependencies]) => ~dependencies.indexOf(name) && handlers.has(parent))
         .map(([parent]) => parent));
 }
 


### PR DESCRIPTION
**Issue:**
When you have a lot of dependencies functions runs 3 times on the same collection.
**Solution:**
It can be optimized by using reduce